### PR TITLE
chore(#25): Add CHT instance link

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ curl -X PUT -H "Content-Type: text/plain" http://admin:password@localhost:5988/a
 2. Create a file named `.env` under `/mediator` folder, copy over the contents of `/mediator/.env.template` and update the `CHT_USERNAME` and `CHT_PASSWORD` values with the admin credentials of your CHT instance.
 3. Set up a proxy to your local CHT instance by running using something like [nginx-local-ip](https://github.com/medic/nginx-local-ip) or [ngrok](https://ngrok.com/) and update the `CHT_URL` value in the `.env` file with the new URL.
 4. Ensure you have [cht-conf](https://www.npmjs.com/package/cht-conf) installed and run `cht --local` to compile and upload the app settings configuration to your local CHT instance.
-5. To verify if the configuration is loaded correctly is to create a `Patient` and to access a URL like https://*****.my.local-ip.co/#/contacts/patientUUID/report/interop_follow_up. This should retrieve correctly the follow up form.
+5. To verify if the configuration is loaded correctly is to create a `Patient` and to access a URL like `https://*****.my.local-ip.co/#/contacts/patientUUID/report/interop_follow_up`. This should retrieve correctly the follow up form.
 6. To verify if the configuration in CouchDB, access `http://localhost:5984/_utils/#database/medic/settings`.
  
 ### Test the Loss to Follow-Up (LTFU) Flow

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Services are currently available at these URLs:
 * **OpenHIM Admin Console** - [https://interoperability.dev.medicmobile.org](https://interoperability.dev.medicmobile.org).
 * **OpenHIM Mediator** - [https://interoperability.dev.medicmobile.org/mediator](https://interoperability.dev.medicmobile.org/mediator). 
 * **HAPI FHIR** - TODO
-* **CHT with LTFU configuration** - TODO
+* **CHT with LTFU configuration** - [https://interop-cht-test.dev.medicmobile.org/](https://interop-cht-test.dev.medicmobile.org/). 
 
 [GitHub repository for the kubernetes configuration](https://github.com/medic/interoperability-kubernetes/).
 


### PR DESCRIPTION
# Description

Add CHT instance link to the documentation. 

[medic/interoperability#25](https://github.com/medic/interoperability/issues/25)

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.