### PR TITLE
chore(#25):Remove HAPI FHIR link from doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Services are currently available at these URLs:
 
 * **OpenHIM Admin Console** - [https://interoperability.dev.medicmobile.org](https://interoperability.dev.medicmobile.org).
 * **OpenHIM Mediator** - [https://interoperability.dev.medicmobile.org/mediator](https://interoperability.dev.medicmobile.org/mediator). 
-* **HAPI FHIR** - TODO
 * **CHT with LTFU configuration** - [https://interop-cht-test.dev.medicmobile.org/](https://interop-cht-test.dev.medicmobile.org/). 
 
 [GitHub repository for the kubernetes configuration](https://github.com/medic/interoperability-kubernetes/).


### PR DESCRIPTION
# Description

Removes HAPI FHIR link from the `README`, as that link it's not available to the public. 

[medic/interoperability#25](https://github.com/medic/interoperability/issues/25)

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.