### PR TITLE
chore(#25): Add FHIR Resources in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,15 @@ Services are currently available at these URLs:
 
 [GitHub repository for the kubernetes configuration](https://github.com/medic/interoperability-kubernetes/).
 
-### Workflow Diagram
+### Workflow Sequence Diagram
 ![](./docs/sequence-diagram/diagram.png) 
+
+### FHIR Resources
+The following [FHIR Resources](https://www.hl7.org/fhir/resource.html) are used to implement the flow above:
+- [Patient](https://www.hl7.org/fhir/patient.html)
+- [Encounter](https://build.fhir.org/encounter.html)
+- [Subscription](https://build.fhir.org/subscription.html)
+- [Organization](https://build.fhir.org/organization.html) - *Work in Progress*
 
 ## Get Started
 
@@ -82,9 +89,6 @@ curl -X PUT -H "Content-Type: text/plain" http://admin:password@localhost:5988/a
 6. To verify if the configuration in CouchDB, access `http://localhost:5984/_utils/#database/medic/settings`.
  
 ### Test the Loss to Follow-Up (LTFU) Flow
-TODO
-
-#### Postman collection
 TODO
 
 ### Shutdown the servers


### PR DESCRIPTION
# Description

Add FHIR Resources in the README

[medic/interoperability#25](https://github.com/medic/interoperability/issues/25)

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.