### PR TITLE
chore(#25): Add a Postman collection that tests the LTFU flow e2e

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The following steps assume that you were successful in running locally OpenHIM a
     ![](./docs/images/transaction-log-encounter.png)
    1. If your callback URL test service was set up correctly, you should receive a notification from the mediator.
 
-An API test collection that can be used with Postman or similar tools can be found under `/docs/local-test`. This collection allows testing the LTFU flow whiel running the instances locally.
+An API test collection that can be used with Postman or similar tools can be found under `/docs/local-test`. This collection allows testing the LTFU flow while running the instances locally.
 
 ### Shutdown the servers
 - To shut-down the containers run `./startup.sh down` to stop the instances.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ The following steps assume that you were successful in running locally OpenHIM a
     ![](./docs/images/transaction-log-encounter.png)
    1. If your callback URL test service was set up correctly, you should receive a notification from the mediator.
 
+An API test collection that can be used with Postman or similar tools can be found under `/docs/local-test`. This collection allows testing the LTFU flow whiel running the instances locally.
+
 ### Shutdown the servers
 - To shut-down the containers run `./startup.sh down` to stop the instances.
 - To then restart the containers, run `./startup.sh up`. You do not need to run `init` again like you did in the initial install above.

--- a/docs/local-test/Interoperability PoC LTFU Flow.postman_collection.json
+++ b/docs/local-test/Interoperability PoC LTFU Flow.postman_collection.json
@@ -1,625 +1,571 @@
 {
-	"info": {
-		"_postman_id": "8b09c5d2-ec9f-4e15-ac33-3bb45e05cb5f",
-		"name": "Interoperability PoC LTFU Flow",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "7615796"
-	},
-	"item": [
-		{
-			"name": "Mediator Status",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is 200\", () => {",
-							"  pm.expect(pm.response.code).to.eql(200);",
-							"});",
-							"",
-							"pm.test(\"Mediator response is success\", () => {",
-							"    const responseJson = pm.response.json();",
-							"    pm.expect(responseJson.status).to.eql('success');",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "{{OPENHIM_PASSWORD}}",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "{{OPENHIM_USER}}",
-							"type": "string"
-						}
-					]
-				},
-				"method": "GET",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": ""
-				},
-				"url": {
-					"raw": "http://localhost:5001/mediator/",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "5001",
-					"path": [
-						"mediator",
-						""
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "CHT Create Place",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"let response = pm.response.json();",
-							"",
-							"pm.collectionVariables.set(\"place\", response.id);",
-							"",
-							"pm.test(\"Status code is 200\", () => {",
-							"  pm.expect(pm.response.code).to.eql(200);",
-							"});",
-							"",
-							"pm.test(\"Place creation is successful\", () => {",
-							"    const responseJson = pm.response.json();",
-							"    pm.expect(responseJson.ok).to.eql(true);",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "{{CHT_ADMIN_PASSWORD}}",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "{{CHT_ADMIN_USER}}",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "Host",
-						"value": "localhost:5988",
-						"type": "text",
-						"disabled": true
-					},
-					{
-						"key": "X-OpenRosa-Version",
-						"value": "1.0",
-						"type": "text",
-						"disabled": true
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n  \"name\": \"CHP Branch Two\",\n  \"type\": \"district_hospital\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:5988/api/v1/places",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "5988",
-					"path": [
-						"api",
-						"v1",
-						"places"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "CHT Create CHW User",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							""
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"let response = pm.response.json();",
-							"let req = JSON.parse(request.data);",
-							"",
-							"pm.collectionVariables.set(\"chwUsername\", req.username);",
-							"pm.collectionVariables.set(\"chwPassword\", req.password);",
-							"",
-							"pm.collectionVariables.set(\"contactId\", response.contact.id);",
-							"",
-							"pm.test(\"Status code is 200\", () => {",
-							"  pm.expect(pm.response.code).to.eql(200);",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "{{CHT_ADMIN_PASSWORD}}",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "{{CHT_ADMIN_USER}}",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "Host",
-						"value": "localhost:5988",
-						"type": "text",
-						"disabled": true
-					},
-					{
-						"key": "X-OpenRosa-Version",
-						"value": "1.0",
-						"type": "text",
-						"disabled": true
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"password\": \"Dakar1234\",\n    \"username\": \"maria\",\n    \"type\": \"chw\",\n    \"place\": {\n        \"name\": \"CHP Branch One\",\n        \"type\": \"district_hospital\",\n        \"parent\": \"{{place}}\"\n    },\n    \"contact\": {\n        \"name\": \"Maria Blob\",\n        \"phone\": \"+2868917046\"\n    }\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:5988/api/v2/users",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "5988",
-					"path": [
-						"api",
-						"v2",
-						"users"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "CHT Create Patient",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"let response = pm.response.json();",
-							"",
-							"pm.collectionVariables.set(\"patient\", response.id);",
-							"",
-							"pm.test(\"Status code is 200\", () => {",
-							"  pm.expect(pm.response.code).to.eql(200);",
-							"});",
-							"",
-							"pm.test(\"Patient creation is successful\", () => {",
-							"    const responseJson = pm.response.json();",
-							"    pm.expect(responseJson.ok).to.eql(true);",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "{{chwPassword}}",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "{{chwUsername}}",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n  \"name\": \"John Test\",\n  \"phone\": \"+2548277217095\",\n  \"date_of_birth\":\"1980-06-06\",\n  \"sex\":\"male\",\n  \"type\": \"person\",\n  \"role\": \"patient\",\n  \"contact_type\": \"patient\",\n  \"place\": \"{{place}}\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:5988/api/v1/people",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "5988",
-					"path": [
-						"api",
-						"v1",
-						"people"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "FHIR Retrieve Patient ID",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							""
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is 200\", () => {",
-							"  pm.expect(pm.response.code).to.eql(200);",
-							"});",
-							"",
-							"pm.test(\"Patient creation is successful in FHIR DB\", () => {",
-							"    const responseJson = pm.response.json();",
-							"    pm.expect(responseJson.total).to.eql(1);",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "{{OPENHIM_PASSWORD}}",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "{{OPENHIM_USER}}",
-							"type": "string"
-						}
-					]
-				},
-				"method": "GET",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:5001/fhir/Patient/?identifier={{patient}}",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "5001",
-					"path": [
-						"fhir",
-						"Patient",
-						""
-					],
-					"query": [
-						{
-							"key": "identifier",
-							"value": "{{patient}}"
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Mediator Send Service request",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							""
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"let response = pm.response.json();",
-							"",
-							"pm.collectionVariables.set(\"encounterUrl\", response.criteria);",
-							"",
-							"pm.test(\"Status code is 201\", () => {",
-							"  pm.expect(pm.response.code).to.eql(201);",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "{{OPENHIM_PASSWORD}}",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "{{OPENHIM_USER}}",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{ \n    \"patient_id\": \"{{patient}}\", \n    \"callback_url\": \"https://interop.free.beeceptor.com/callback\" \n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:5001/mediator/service-request",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "5001",
-					"path": [
-						"mediator",
-						"service-request"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "CHT Submit Form",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							""
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is 201\", () => {",
-							"  pm.expect(pm.response.code).to.eql(201);",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "{{chwPassword}}",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "{{chwUsername}}",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"docs\": [\n        {\n            \"form\": \"interop_follow_up\",\n            \"type\": \"data_record\",\n            \"contact\": {\n                \"_id\": \"{{contactId}}\",\n                \"parent\": {\n                    \"_id\": \"{{place}}\" \n                }\n            },\n            \"from\": \"\",\n            \"hidden_fields\": [\n                \"meta\"\n            ],\n            \"fields\": {\n                \"inputs\": {\n                    \"meta\": {\n                        \"location\": {\n                            \"lat\": \"\",\n                            \"long\": \"\",\n                            \"error\": \"\",\n                            \"message\": \"\"\n                        },\n                        \"deprecatedID\": \"\"\n                    },\n                    \"source\": \"task\",\n                    \"is_covid_vaccine_referral\": \"\",\n                    \"contact\": {\n                        \"_id\": \"{{patient}}\",\n                        \"name\": \"John Test\",\n                        \"date_of_birth\": \"1980-06-06\",\n                        \"sex\": \"male\",\n                        \"parent\": {\n                            \"parent\": {\n                                \"contact\": {\n                                    \"name\": \"\",\n                                    \"phone\": \"\"\n                                }\n                            }\n                        }\n                    }\n                },\n                \"vaccination_details\": {\n                    \"interop_follow_up\": \"yes\"\n                },\n                \"meta\": {\n                    \"instanceID\": \"uuid:0fbe39f1-8aa5-477a-89ea-863831766766\"\n                }\n            },\n            \"_id\": \"{{$guid}}\",\n            \"_rev\": \"1-{{$guid}}\"\n        }\n    ],\n    \"new_edits\": false\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:5988/medic/_bulk_docs",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "5988",
-					"path": [
-						"medic",
-						"_bulk_docs"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "FHIR Retrieve Encounter",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Encounter creation is successful in FHIR DB\", () => {",
-							"    const responseJson = pm.response.json();",
-							"    pm.expect(responseJson.total).to.eql(1);",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "{{OPENHIM_PASSWORD}}",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "{{OPENHIM_USER}}",
-							"type": "string"
-						}
-					]
-				},
-				"method": "GET",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n  \"resourceType\": \"Encounter\",\n  \"identifier\": [\n    {\n      \"use\": \"official\",\n      \"value\": \"96eb2845-15dd-4b80-9cf2-a853e4443e1c\"\n    }\n  ],\n  \"status\": \"finished\",\n  \"class\": \"outpatient\",\n  \"type\": [\n    {\n      \"text\": \"Community health worker visit\"\n    }\n  ],\n  \"subject\": \"96eb2845-15dd-4b80-9cf2-a853e4443e1c\",\n  \"participant\": [\n    {\n      \"type\": [\n        {\n          \"text\": \"Community health worker\"\n        }\n      ]\n    }\n  ]\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:5001/fhir/{{encounterUrl}}",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "5001",
-					"path": [
-						"fhir",
-						"{{encounterUrl}}"
-					]
-				}
-			},
-			"response": []
-		}
-	],
-	"variable": [
-		{
-			"key": "place",
-			"value": ""
-		},
-		{
-			"key": "userId",
-			"value": ""
-		},
-		{
-			"key": "chwUsername",
-			"value": ""
-		},
-		{
-			"key": "chwPassword",
-			"value": ""
-		},
-		{
-			"key": "contactId",
-			"value": ""
-		},
-		{
-			"key": "patient",
-			"value": ""
-		},
-		{
-			"key": "encounterUrl",
-			"value": ""
-		}
-	]
+  "info": {
+    "_postman_id": "8b09c5d2-ec9f-4e15-ac33-3bb45e05cb5f",
+    "name": "Interoperability PoC LTFU Flow",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "7615796"
+  },
+  "item": [
+    {
+      "name": "Mediator Status",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 200\", () => {",
+              "  pm.expect(pm.response.code).to.eql(200);",
+              "});",
+              "",
+              "pm.test(\"Mediator response is success\", () => {",
+              "    const responseJson = pm.response.json();",
+              "    pm.expect(responseJson.status).to.eql('success');",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "auth": {
+          "type": "basic",
+          "basic": [
+            {
+              "key": "password",
+              "value": "{{OPENHIM_PASSWORD}}",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "{{OPENHIM_USER}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": ""
+        },
+        "url": {
+          "raw": "http://localhost:5001/mediator/",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "5001",
+          "path": ["mediator", ""]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "CHT Create Place",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "let response = pm.response.json();",
+              "",
+              "pm.collectionVariables.set(\"place\", response.id);",
+              "",
+              "pm.test(\"Status code is 200\", () => {",
+              "  pm.expect(pm.response.code).to.eql(200);",
+              "});",
+              "",
+              "pm.test(\"Place creation is successful\", () => {",
+              "    const responseJson = pm.response.json();",
+              "    pm.expect(responseJson.ok).to.eql(true);",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "basic",
+          "basic": [
+            {
+              "key": "password",
+              "value": "{{CHT_ADMIN_PASSWORD}}",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "{{CHT_ADMIN_USER}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Host",
+            "value": "localhost:5988",
+            "type": "text",
+            "disabled": true
+          },
+          {
+            "key": "X-OpenRosa-Version",
+            "value": "1.0",
+            "type": "text",
+            "disabled": true
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"name\": \"CHP Branch Two\",\n  \"type\": \"district_hospital\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:5988/api/v1/places",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "5988",
+          "path": ["api", "v1", "places"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "CHT Create CHW User",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [""],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "let response = pm.response.json();",
+              "let req = JSON.parse(request.data);",
+              "",
+              "pm.collectionVariables.set(\"chwUsername\", req.username);",
+              "pm.collectionVariables.set(\"chwPassword\", req.password);",
+              "",
+              "pm.collectionVariables.set(\"contactId\", response.contact.id);",
+              "",
+              "pm.test(\"Status code is 200\", () => {",
+              "  pm.expect(pm.response.code).to.eql(200);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "basic",
+          "basic": [
+            {
+              "key": "password",
+              "value": "{{CHT_ADMIN_PASSWORD}}",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "{{CHT_ADMIN_USER}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Host",
+            "value": "localhost:5988",
+            "type": "text",
+            "disabled": true
+          },
+          {
+            "key": "X-OpenRosa-Version",
+            "value": "1.0",
+            "type": "text",
+            "disabled": true
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"password\": \"Dakar1234\",\n    \"username\": \"maria\",\n    \"type\": \"chw\",\n    \"place\": {\n        \"name\": \"CHP Branch One\",\n        \"type\": \"district_hospital\",\n        \"parent\": \"{{place}}\"\n    },\n    \"contact\": {\n        \"name\": \"Maria Blob\",\n        \"phone\": \"+2868917046\"\n    }\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:5988/api/v2/users",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "5988",
+          "path": ["api", "v2", "users"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "CHT Create Patient",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "let response = pm.response.json();",
+              "",
+              "pm.collectionVariables.set(\"patient\", response.id);",
+              "",
+              "pm.test(\"Status code is 200\", () => {",
+              "  pm.expect(pm.response.code).to.eql(200);",
+              "});",
+              "",
+              "pm.test(\"Patient creation is successful\", () => {",
+              "    const responseJson = pm.response.json();",
+              "    pm.expect(responseJson.ok).to.eql(true);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [""],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "basic",
+          "basic": [
+            {
+              "key": "password",
+              "value": "{{chwPassword}}",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "{{chwUsername}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"name\": \"John Test\",\n  \"phone\": \"+2548277217095\",\n  \"date_of_birth\":\"1980-06-06\",\n  \"sex\":\"male\",\n  \"type\": \"person\",\n  \"role\": \"patient\",\n  \"contact_type\": \"patient\",\n  \"place\": \"{{place}}\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:5988/api/v1/people",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "5988",
+          "path": ["api", "v1", "people"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "FHIR Retrieve Patient ID",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [""],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 200\", () => {",
+              "  pm.expect(pm.response.code).to.eql(200);",
+              "});",
+              "",
+              "pm.test(\"Patient creation is successful in FHIR DB\", () => {",
+              "    const responseJson = pm.response.json();",
+              "    pm.expect(responseJson.total).to.eql(1);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "auth": {
+          "type": "basic",
+          "basic": [
+            {
+              "key": "password",
+              "value": "{{OPENHIM_PASSWORD}}",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "{{OPENHIM_USER}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:5001/fhir/Patient/?identifier={{patient}}",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "5001",
+          "path": ["fhir", "Patient", ""],
+          "query": [
+            {
+              "key": "identifier",
+              "value": "{{patient}}"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Mediator Send Service request",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [""],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "let response = pm.response.json();",
+              "",
+              "pm.collectionVariables.set(\"encounterUrl\", response.criteria);",
+              "",
+              "pm.test(\"Status code is 201\", () => {",
+              "  pm.expect(pm.response.code).to.eql(201);",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "basic",
+          "basic": [
+            {
+              "key": "password",
+              "value": "{{OPENHIM_PASSWORD}}",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "{{OPENHIM_USER}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{ \n    \"patient_id\": \"{{patient}}\", \n    \"callback_url\": \"https://interop.free.beeceptor.com/callback\" \n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:5001/mediator/service-request",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "5001",
+          "path": ["mediator", "service-request"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "CHT Submit Form",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [""],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 201\", () => {",
+              "  pm.expect(pm.response.code).to.eql(201);",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "basic",
+          "basic": [
+            {
+              "key": "password",
+              "value": "{{chwPassword}}",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "{{chwUsername}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"docs\": [\n        {\n            \"form\": \"interop_follow_up\",\n            \"type\": \"data_record\",\n            \"contact\": {\n                \"_id\": \"{{contactId}}\",\n                \"parent\": {\n                    \"_id\": \"{{place}}\" \n                }\n            },\n            \"from\": \"\",\n            \"hidden_fields\": [\n                \"meta\"\n            ],\n            \"fields\": {\n                \"inputs\": {\n                    \"meta\": {\n                        \"location\": {\n                            \"lat\": \"\",\n                            \"long\": \"\",\n                            \"error\": \"\",\n                            \"message\": \"\"\n                        },\n                        \"deprecatedID\": \"\"\n                    },\n                    \"source\": \"task\",\n                    \"is_covid_vaccine_referral\": \"\",\n                    \"contact\": {\n                        \"_id\": \"{{patient}}\",\n                        \"name\": \"John Test\",\n                        \"date_of_birth\": \"1980-06-06\",\n                        \"sex\": \"male\",\n                        \"parent\": {\n                            \"parent\": {\n                                \"contact\": {\n                                    \"name\": \"\",\n                                    \"phone\": \"\"\n                                }\n                            }\n                        }\n                    }\n                },\n                \"vaccination_details\": {\n                    \"interop_follow_up\": \"yes\"\n                },\n                \"meta\": {\n                    \"instanceID\": \"uuid:0fbe39f1-8aa5-477a-89ea-863831766766\"\n                }\n            },\n            \"_id\": \"{{$guid}}\",\n            \"_rev\": \"1-{{$guid}}\"\n        }\n    ],\n    \"new_edits\": false\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:5988/medic/_bulk_docs",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "5988",
+          "path": ["medic", "_bulk_docs"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "FHIR Retrieve Encounter",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Encounter creation is successful in FHIR DB\", () => {",
+              "    const responseJson = pm.response.json();",
+              "    pm.expect(responseJson.total).to.eql(1);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "auth": {
+          "type": "basic",
+          "basic": [
+            {
+              "key": "password",
+              "value": "{{OPENHIM_PASSWORD}}",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "{{OPENHIM_USER}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"resourceType\": \"Encounter\",\n  \"identifier\": [\n    {\n      \"use\": \"official\",\n      \"value\": \"96eb2845-15dd-4b80-9cf2-a853e4443e1c\"\n    }\n  ],\n  \"status\": \"finished\",\n  \"class\": \"outpatient\",\n  \"type\": [\n    {\n      \"text\": \"Community health worker visit\"\n    }\n  ],\n  \"subject\": \"96eb2845-15dd-4b80-9cf2-a853e4443e1c\",\n  \"participant\": [\n    {\n      \"type\": [\n        {\n          \"text\": \"Community health worker\"\n        }\n      ]\n    }\n  ]\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:5001/fhir/{{encounterUrl}}",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "5001",
+          "path": ["fhir", "{{encounterUrl}}"]
+        }
+      },
+      "response": []
+    }
+  ],
+  "variable": [
+    {
+      "key": "place",
+      "value": ""
+    },
+    {
+      "key": "userId",
+      "value": ""
+    },
+    {
+      "key": "chwUsername",
+      "value": ""
+    },
+    {
+      "key": "chwPassword",
+      "value": ""
+    },
+    {
+      "key": "contactId",
+      "value": ""
+    },
+    {
+      "key": "patient",
+      "value": ""
+    },
+    {
+      "key": "encounterUrl",
+      "value": ""
+    }
+  ]
 }

--- a/docs/local-test/Interoperability PoC LTFU Flow.postman_collection.json
+++ b/docs/local-test/Interoperability PoC LTFU Flow.postman_collection.json
@@ -606,10 +606,6 @@
 			"value": ""
 		},
 		{
-			"key": "chwPAssword",
-			"value": ""
-		},
-		{
 			"key": "chwPassword",
 			"value": ""
 		},

--- a/docs/local-test/Interoperability PoC LTFU Flow.postman_collection.json
+++ b/docs/local-test/Interoperability PoC LTFU Flow.postman_collection.json
@@ -1,0 +1,629 @@
+{
+	"info": {
+		"_postman_id": "8b09c5d2-ec9f-4e15-ac33-3bb45e05cb5f",
+		"name": "Interoperability PoC LTFU Flow",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "7615796"
+	},
+	"item": [
+		{
+			"name": "Mediator Status",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", () => {",
+							"  pm.expect(pm.response.code).to.eql(200);",
+							"});",
+							"",
+							"pm.test(\"Mediator response is success\", () => {",
+							"    const responseJson = pm.response.json();",
+							"    pm.expect(responseJson.status).to.eql('success');",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "{{OPENHIM_PASSWORD}}",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "{{OPENHIM_USER}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://localhost:5001/mediator/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "5001",
+					"path": [
+						"mediator",
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "CHT Create Place",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"let response = pm.response.json();",
+							"",
+							"pm.collectionVariables.set(\"place\", response.id);",
+							"",
+							"pm.test(\"Status code is 200\", () => {",
+							"  pm.expect(pm.response.code).to.eql(200);",
+							"});",
+							"",
+							"pm.test(\"Place creation is successful\", () => {",
+							"    const responseJson = pm.response.json();",
+							"    pm.expect(responseJson.ok).to.eql(true);",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "{{CHT_ADMIN_PASSWORD}}",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "{{CHT_ADMIN_USER}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Host",
+						"value": "localhost:5988",
+						"type": "text",
+						"disabled": true
+					},
+					{
+						"key": "X-OpenRosa-Version",
+						"value": "1.0",
+						"type": "text",
+						"disabled": true
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"name\": \"CHP Branch Two\",\n  \"type\": \"district_hospital\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:5988/api/v1/places",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "5988",
+					"path": [
+						"api",
+						"v1",
+						"places"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "CHT Create CHW User",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"let response = pm.response.json();",
+							"let req = JSON.parse(request.data);",
+							"",
+							"pm.collectionVariables.set(\"chwUsername\", req.username);",
+							"pm.collectionVariables.set(\"chwPassword\", req.password);",
+							"",
+							"pm.collectionVariables.set(\"contactId\", response.contact.id);",
+							"",
+							"pm.test(\"Status code is 200\", () => {",
+							"  pm.expect(pm.response.code).to.eql(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "{{CHT_ADMIN_PASSWORD}}",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "{{CHT_ADMIN_USER}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Host",
+						"value": "localhost:5988",
+						"type": "text",
+						"disabled": true
+					},
+					{
+						"key": "X-OpenRosa-Version",
+						"value": "1.0",
+						"type": "text",
+						"disabled": true
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"password\": \"Dakar1234\",\n    \"username\": \"maria\",\n    \"type\": \"chw\",\n    \"place\": {\n        \"name\": \"CHP Branch One\",\n        \"type\": \"district_hospital\",\n        \"parent\": \"{{place}}\"\n    },\n    \"contact\": {\n        \"name\": \"Maria Blob\",\n        \"phone\": \"+2868917046\"\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:5988/api/v2/users",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "5988",
+					"path": [
+						"api",
+						"v2",
+						"users"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "CHT Create Patient",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"let response = pm.response.json();",
+							"",
+							"pm.collectionVariables.set(\"patient\", response.id);",
+							"",
+							"pm.test(\"Status code is 200\", () => {",
+							"  pm.expect(pm.response.code).to.eql(200);",
+							"});",
+							"",
+							"pm.test(\"Patient creation is successful\", () => {",
+							"    const responseJson = pm.response.json();",
+							"    pm.expect(responseJson.ok).to.eql(true);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "{{chwPassword}}",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "{{chwUsername}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"name\": \"John Test\",\n  \"phone\": \"+2548277217095\",\n  \"date_of_birth\":\"1980-06-06\",\n  \"sex\":\"male\",\n  \"type\": \"person\",\n  \"role\": \"patient\",\n  \"contact_type\": \"patient\",\n  \"place\": \"{{place}}\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:5988/api/v1/people",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "5988",
+					"path": [
+						"api",
+						"v1",
+						"people"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "FHIR Retrieve Patient ID",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", () => {",
+							"  pm.expect(pm.response.code).to.eql(200);",
+							"});",
+							"",
+							"pm.test(\"Patient creation is successful in FHIR DB\", () => {",
+							"    const responseJson = pm.response.json();",
+							"    pm.expect(responseJson.total).to.eql(1);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "{{OPENHIM_PASSWORD}}",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "{{OPENHIM_USER}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:5001/fhir/Patient/?identifier={{patient}}",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "5001",
+					"path": [
+						"fhir",
+						"Patient",
+						""
+					],
+					"query": [
+						{
+							"key": "identifier",
+							"value": "{{patient}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Mediator Send Service request",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"let response = pm.response.json();",
+							"",
+							"pm.collectionVariables.set(\"encounterUrl\", response.criteria);",
+							"",
+							"pm.test(\"Status code is 201\", () => {",
+							"  pm.expect(pm.response.code).to.eql(201);",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "{{OPENHIM_PASSWORD}}",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "{{OPENHIM_USER}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{ \n    \"patient_id\": \"{{patient}}\", \n    \"callback_url\": \"https://interop.free.beeceptor.com/callback\" \n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:5001/mediator/service-request",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "5001",
+					"path": [
+						"mediator",
+						"service-request"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "CHT Submit Form",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 201\", () => {",
+							"  pm.expect(pm.response.code).to.eql(201);",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "{{chwPassword}}",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "{{chwUsername}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"docs\": [\n        {\n            \"form\": \"interop_follow_up\",\n            \"type\": \"data_record\",\n            \"contact\": {\n                \"_id\": \"{{contactId}}\",\n                \"parent\": {\n                    \"_id\": \"{{place}}\" \n                }\n            },\n            \"from\": \"\",\n            \"hidden_fields\": [\n                \"meta\"\n            ],\n            \"fields\": {\n                \"inputs\": {\n                    \"meta\": {\n                        \"location\": {\n                            \"lat\": \"\",\n                            \"long\": \"\",\n                            \"error\": \"\",\n                            \"message\": \"\"\n                        },\n                        \"deprecatedID\": \"\"\n                    },\n                    \"source\": \"task\",\n                    \"is_covid_vaccine_referral\": \"\",\n                    \"contact\": {\n                        \"_id\": \"{{patient}}\",\n                        \"name\": \"John Test\",\n                        \"date_of_birth\": \"1980-06-06\",\n                        \"sex\": \"male\",\n                        \"parent\": {\n                            \"parent\": {\n                                \"contact\": {\n                                    \"name\": \"\",\n                                    \"phone\": \"\"\n                                }\n                            }\n                        }\n                    }\n                },\n                \"vaccination_details\": {\n                    \"interop_follow_up\": \"yes\"\n                },\n                \"meta\": {\n                    \"instanceID\": \"uuid:0fbe39f1-8aa5-477a-89ea-863831766766\"\n                }\n            },\n            \"_id\": \"{{$guid}}\",\n            \"_rev\": \"1-{{$guid}}\"\n        }\n    ],\n    \"new_edits\": false\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:5988/medic/_bulk_docs",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "5988",
+					"path": [
+						"medic",
+						"_bulk_docs"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "FHIR Retrieve Encounter",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Encounter creation is successful in FHIR DB\", () => {",
+							"    const responseJson = pm.response.json();",
+							"    pm.expect(responseJson.total).to.eql(1);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "{{OPENHIM_PASSWORD}}",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "{{OPENHIM_USER}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"resourceType\": \"Encounter\",\n  \"identifier\": [\n    {\n      \"use\": \"official\",\n      \"value\": \"96eb2845-15dd-4b80-9cf2-a853e4443e1c\"\n    }\n  ],\n  \"status\": \"finished\",\n  \"class\": \"outpatient\",\n  \"type\": [\n    {\n      \"text\": \"Community health worker visit\"\n    }\n  ],\n  \"subject\": \"96eb2845-15dd-4b80-9cf2-a853e4443e1c\",\n  \"participant\": [\n    {\n      \"type\": [\n        {\n          \"text\": \"Community health worker\"\n        }\n      ]\n    }\n  ]\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:5001/fhir/{{encounterUrl}}",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "5001",
+					"path": [
+						"fhir",
+						"{{encounterUrl}}"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"variable": [
+		{
+			"key": "place",
+			"value": ""
+		},
+		{
+			"key": "userId",
+			"value": ""
+		},
+		{
+			"key": "chwUsername",
+			"value": ""
+		},
+		{
+			"key": "chwPAssword",
+			"value": ""
+		},
+		{
+			"key": "chwPassword",
+			"value": ""
+		},
+		{
+			"key": "contactId",
+			"value": ""
+		},
+		{
+			"key": "patient",
+			"value": ""
+		},
+		{
+			"key": "encounterUrl",
+			"value": ""
+		}
+	]
+}

--- a/docs/local-test/README.md
+++ b/docs/local-test/README.md
@@ -1,0 +1,8 @@
+## Local testing of LTFU flow with [Postman](https://www.postman.com/) or similar tools
+This folder contains a collection of API calls to end-to-end test the CHT - Mediator - FHIR API calls that simulate an LTFU flow on local instances.
+
+The following steps assume that you were successful in running locally OpenHIM and the CHT with the LTFU configuration.
+
+1. Import the `dev.json` environment file under Postman > Environments. It contains the OpenHIM and CHT admin credentials of your local instances.
+1. Import the `Interoperability PoC LTFU Flow.postman_collection.json` collection under Postman > Collections.
+1. Run the collection! You can check the Patient & Encounter creation in both CHT and OpenHIM Admin Console. 

--- a/docs/local-test/dev.json
+++ b/docs/local-test/dev.json
@@ -1,33 +1,33 @@
 {
-	"id": "2e553c09-22c1-4ca2-a1b2-1ecd6d711bf4",
-	"name": "dev",
-	"values": [
-		{
-			"key": "OPENHIM_USER",
-			"value": "interop-client",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "OPENHIM_PASSWORD",
-			"value": "interop-password",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "CHT_ADMIN_USER",
-			"value": "admin",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "CHT_ADMIN_PASSWORD",
-			"value": "password",
-			"type": "default",
-			"enabled": true
-		}
-	],
-	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2023-04-06T13:16:43.883Z",
-	"_postman_exported_using": "Postman/10.12.10"
+  "id": "2e553c09-22c1-4ca2-a1b2-1ecd6d711bf4",
+  "name": "dev",
+  "values": [
+    {
+      "key": "OPENHIM_USER",
+      "value": "interop-client",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "OPENHIM_PASSWORD",
+      "value": "interop-password",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "CHT_ADMIN_USER",
+      "value": "admin",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "CHT_ADMIN_PASSWORD",
+      "value": "password",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2023-04-06T13:16:43.883Z",
+  "_postman_exported_using": "Postman/10.12.10"
 }

--- a/docs/local-test/dev.json
+++ b/docs/local-test/dev.json
@@ -1,0 +1,33 @@
+{
+	"id": "2e553c09-22c1-4ca2-a1b2-1ecd6d711bf4",
+	"name": "dev",
+	"values": [
+		{
+			"key": "OPENHIM_USER",
+			"value": "interop-client",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "OPENHIM_PASSWORD",
+			"value": "interop-password",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "CHT_ADMIN_USER",
+			"value": "admin",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "CHT_ADMIN_PASSWORD",
+			"value": "password",
+			"type": "default",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2023-04-06T13:16:43.883Z",
+	"_postman_exported_using": "Postman/10.12.10"
+}


### PR DESCRIPTION
# Description

Add a Postman collection that tests the LTFU flow, end-to-end.

It is meant for more technical users who want to understand the API calls and their payloads made in the LTFU, while running all the instances locally.

[medic/interoperability#25](https://github.com/medic/interoperability/issues/25)

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.